### PR TITLE
Implemented Alternative Checkboxes Style Settings Toggle

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -1070,44 +1070,63 @@
 	/* === (Alternate) Checkboxes === */
 
 		/* common (only for Tasks) */
-		input[data-task=">"]:checked, li[data-task=">"] > input:checked, li[data-task=">"] > p > input:checked,
-		input[data-task="-"]:checked, li[data-task="-"] > input:checked, li[data-task="-"] > p > input:checked,
-		input[data-task="<"]:checked, li[data-task="<"] > input:checked, li[data-task="<"] > p > input:checked {
+		body.enable-alternative-checkboxes input[data-task=">"]:checked,
+		body.enable-alternative-checkboxes li[data-task=">"] > input:checked, li[data-task=">"] > p > input:checked,
+		body.enable-alternative-checkboxes input[data-task="-"]:checked,
+		body.enable-alternative-checkboxes li[data-task="-"] > input:checked, li[data-task="-"] > p > input:checked,
+		body.enable-alternative-checkboxes input[data-task="<"]:checked,
+		body.enable-alternative-checkboxes li[data-task="<"] > input:checked, li[data-task="<"] > p > input:checked {
 			--checkbox-marker-color: transparent;
 			background-color: currentColor;
 		}
 		/* Common (only for Info / Higlights) - Include lock the state for mouse click */
-		input[data-task="I"]:checked, li[data-task="I"] > input:checked, li[data-task="I"] > p > input:checked,
-		input[data-task="i"]:checked, li[data-task="i"] > input:checked, li[data-task="i"] > p > input:checked,
-		input[data-task="\""]:checked, li[data-task="\""] > input:checked, li[data-task="\""] > p > input:checked,
-		input[data-task="“"]:checked, li[data-task="“"] > input:checked, li[data-task="“"] > p > input:checked,
-		input[data-task="!"]:checked, li[data-task="!"] > input:checked, li[data-task="!"] > p > input:checked,
-		input[data-task="r"]:checked, li[data-task="r"] > input:checked, li[data-task="r"] > p > input:checked,
-		input[data-task="*"]:checked, li[data-task="*"] > input:checked, li[data-task="*"] > p > input:checked {
+		body.enable-alternative-checkboxes input[data-task="I"]:checked,
+		body.enable-alternative-checkboxes li[data-task="I"] > input:checked,
+		body.enable-alternative-checkboxes li[data-task="I"] > p > input:checked,
+		body.enable-alternative-checkboxes input[data-task="i"]:checked,
+		body.enable-alternative-checkboxes li[data-task="i"] > input:checked,
+		body.enable-alternative-checkboxes li[data-task="i"] > p > input:checked,
+		body.enable-alternative-checkboxes input[data-task="\""]:checked,
+		body.enable-alternative-checkboxes li[data-task="\""] > input:checked,
+		body.enable-alternative-checkboxes li[data-task="\""] > p > input:checked,
+		body.enable-alternative-checkboxes input[data-task="“"]:checked,
+		body.enable-alternative-checkboxes li[data-task="“"] > input:checked,
+		body.enable-alternative-checkboxes li[data-task="“"] > p > input:checked,
+		body.enable-alternative-checkboxes input[data-task="!"]:checked,
+		body.enable-alternative-checkboxes li[data-task="!"] > input:checked,
+		body.enable-alternative-checkboxes li[data-task="!"] > p > input:checked,
+		body.enable-alternative-checkboxes input[data-task="r"]:checked,
+		body.enable-alternative-checkboxes li[data-task="r"] > input:checked,
+		body.enable-alternative-checkboxes li[data-task="r"] > p > input:checked,
+		body.enable-alternative-checkboxes input[data-task="*"]:checked,
+		body.enable-alternative-checkboxes li[data-task="*"] > input:checked,
+		body.enable-alternative-checkboxes li[data-task="*"] > p > input:checked {
 			--checkbox-marker-color: transparent;
 			background-color: currentColor;
 			border: none;
 			pointer-events: none;
 		}
-		label.task-list-label:has(> input[data-task="I"]:checked),
-		label.task-list-label:has(> input[data-task="!"]:checked),
-		label.task-list-label:has(> input[data-task="\""]:checked),
-		label.task-list-label:has(> input[data-task="“"]:checked),
-		label.task-list-label:has(> input[data-task="!"]:checked),
-		label.task-list-label:has(> input[data-task="r"]:checked),
-		label.task-list-label:has(> input[data-task="*"]:checked) {
+		body.enable-alternative-checkboxes label.task-list-label:has(> input[data-task="I"]:checked),
+		body.enable-alternative-checkboxes label.task-list-label:has(> input[data-task="!"]:checked),
+		body.enable-alternative-checkboxes label.task-list-label:has(> input[data-task="\""]:checked),
+		body.enable-alternative-checkboxes label.task-list-label:has(> input[data-task="“"]:checked),
+		body.enable-alternative-checkboxes label.task-list-label:has(> input[data-task="!"]:checked),
+		body.enable-alternative-checkboxes label.task-list-label:has(> input[data-task="r"]:checked),
+		body.enable-alternative-checkboxes label.task-list-label:has(> input[data-task="*"]:checked) {
 			pointer-events: none;
 		}
 
 		/* For [/] "/" i.e Partial or Incomplete */
-		.HyperMD-list-line input[data-task="/"]:checked,
-		.markdown-preview-view li[data-task="/"]>input[type="checkbox"]:checked
+		body.enable-alternative-checkboxes .HyperMD-list-line input[data-task="/"]:checked,
+		body.enable-alternative-checkboxes .markdown-preview-view li[data-task="/"]>input[type="checkbox"]:checked
 			{ background-image: linear-gradient(135deg, var(--interactive-accent) 50%, var(--background-primary) 50%); }
-		 input[data-task="/"]:checked:after, li[data-task="/"] > input:checked:after, li[data-task="/"] > p > input:checked:after
+		body.enable-alternative-checkboxes input[data-task="/"]:checked:after, li[data-task="/"] > input:checked:after,
+		body.enable-alternative-checkboxes li[data-task="/"] > p > input:checked:after
 		 	{ background-color: var(--background-modifier-accent); -webkit-mask-image: none; }
 
 		/* For [>] ">" i.e. Defer or Reschedule */
-		input[data-task=">"]:checked, li[data-task=">"] > input:checked, li[data-task=">"] > p > input:checked {
+		body.enable-alternative-checkboxes input[data-task=">"]:checked,
+		body.enable-alternative-checkboxes li[data-task=">"] > input:checked, li[data-task=">"] > p > input:checked {
 			color: var(--text-faint);
 			transform: rotate(90deg);
 			-webkit-mask-position: 50% 100%;
@@ -1115,18 +1134,21 @@
 		}
 
 		/* For [-] "-" i.e. Canceled */
-		input[data-task="-"]:checked, li[data-task="-"] > input:checked, li[data-task="-"] > p > input:checked {
+		body.enable-alternative-checkboxes input[data-task="-"]:checked,
+		body.enable-alternative-checkboxes li[data-task="-"] > input:checked, li[data-task="-"] > p > input:checked {
 			color: var(--text-faint);
 			-webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'%3E%3Cpath fill-rule='evenodd' d='M3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z' clip-rule='evenodd' /%3E%3C/svg%3E");
 		}
-		body:not(.tasks) .markdown-source-view.mod-cm6 .HyperMD-task-line[data-task]:is([data-task="-"]),
-		body:not(.tasks) .markdown-preview-view ul li[data-task="-"].task-list-item.is-checked, body:not(.tasks) li[data-task="-"].task-list-item.is-checked {
+		body.enable-alternative-checkboxes:not(.tasks) .markdown-source-view.mod-cm6 .HyperMD-task-line[data-task]:is([data-task="-"]),
+		body.enable-alternative-checkboxes:not(.tasks) .markdown-preview-view ul li[data-task="-"].task-list-item.is-checked,
+		body.enable-alternative-checkboxes:not(.tasks) li[data-task="-"].task-list-item.is-checked {
 			color: var(--text-faint);
 			text-decoration: line-through solid var(--text-faint) 1px;
 		}
 
 		/* For [<] "<" i.e. Schedule or Meeting */
-		input[data-task="<"]:checked, li[data-task="<"]>input:checked, li[data-task="<"]>p>input:checked {
+		body.enable-alternative-checkboxes input[data-task="<"]:checked, li[data-task="<"]>input:checked,
+		body.enable-alternative-checkboxes li[data-task="<"]>p>input:checked {
 			color: var(--text-faint);
 			border: none;
 			-webkit-mask-image: url('data:image/svg+xml;utf8,<?xml version="1.0" encoding="UTF-8"?><svg id="svg0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><defs><style>.cls-1{fill:none;}</style></defs><rect class="cls-1" width="16" height="16"/><path d="M2.75,15.5H13.25c.83,0,1.5-.67,1.5-1.5V3.5c0-.83-.67-1.5-1.5-1.5h-1.5V.5h-1.5v1.5H5.75V.5h-1.5v1.5h-1.5c-.83,0-1.5,.67-1.5,1.5V14c0,.83,.67,1.5,1.5,1.5Zm0-11.25H13.25v1.5H2.75v-1.5Z"/></svg>');
@@ -1135,40 +1157,47 @@
 		/* INFO / HIGHLIGHTS */
 
 		/* For [I] "I" i.e. Idea or Lightbulb */
-		input[data-task="I"]:checked, li[data-task="I"]>input:checked, li[data-task="I"]>p>input:checked {
+		body.enable-alternative-checkboxes input[data-task="I"]:checked,
+		body.enable-alternative-checkboxes li[data-task="I"]>input:checked,
+		body.enable-alternative-checkboxes li[data-task="I"]>p>input:checked {
 			--checkbox-color-hover: var(--color-yellow);
 			color: var(--color-yellow);
 			-webkit-mask-image: url('data:image/svg+xml;utf8,<?xml version="1.0" encoding="UTF-8"?><svg id="svg0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><defs><style>.cls-1{fill:none;}</style></defs><rect class="cls-1" width="16" height="16"/><g><rect class="cls-1" width="16" height="16"/><path d="M9,1c0-.27-.11-.52-.29-.71-.19-.19-.44-.29-.71-.29s-.52,.11-.71,.29c-.19,.19-.29,.44-.29,.71v1c0,.27,.11,.52,.29,.71,.19,.19,.44,.29,.71,.29s.52-.11,.71-.29c.19-.19,.29-.44,.29-.71V1Zm4.66,2.76c.18-.19,.28-.44,.28-.7,0-.26-.11-.51-.29-.7s-.44-.29-.7-.29c-.26,0-.51,.1-.7,.28l-.71,.71c-.18,.19-.28,.44-.28,.7,0,.26,.11,.51,.29,.7s.44,.29,.7,.29c.26,0,.51-.1,.7-.28l.71-.71Zm2.34,4.24c0,.27-.11,.52-.29,.71-.19,.19-.44,.29-.71,.29h-1c-.27,0-.52-.11-.71-.29-.19-.19-.29-.44-.29-.71s.11-.52,.29-.71c.19-.19,.44-.29,.71-.29h1c.27,0,.52,.11,.71,.29,.19,.19,.29,.44,.29,.71ZM3.05,4.46c.09,.1,.2,.17,.32,.22,.12,.05,.25,.08,.39,.08,.13,0,.26-.02,.39-.07,.12-.05,.23-.12,.33-.22,.09-.09,.17-.21,.22-.33,.05-.12,.08-.25,.07-.39,0-.13-.03-.26-.08-.39-.05-.12-.13-.23-.22-.32l-.71-.71c-.19-.18-.44-.28-.7-.28-.26,0-.51,.11-.7,.29s-.29,.44-.29,.7c0,.26,.1,.51,.28,.7l.71,.71Zm-.05,3.54c0,.27-.11,.52-.29,.71-.19,.19-.44,.29-.71,.29H1c-.27,0-.52-.11-.71-.29-.19-.19-.29-.44-.29-.71s.11-.52,.29-.71c.19-.19,.44-.29,.71-.29h1c.27,0,.52,.11,.71,.29,.19,.19,.29,.44,.29,.71Zm3,6v-1h4v1c0,.53-.21,1.04-.59,1.41-.38,.38-.88,.59-1.41,.59s-1.04-.21-1.41-.59c-.38-.38-.59-.88-.59-1.41Zm4-2c.02-.34,.21-.65,.48-.86,.65-.51,1.13-1.22,1.36-2.02,.23-.8,.21-1.65-.06-2.43-.27-.79-.78-1.47-1.46-1.95-.68-.48-1.49-.74-2.32-.74s-1.64,.26-2.32,.74c-.68,.48-1.19,1.16-1.46,1.95-.27,.79-.29,1.64-.06,2.43,.23,.8,.71,1.5,1.36,2.02,.27,.21,.46,.52,.48,.86h4Z"/></g></svg>');
 		}
 
 		/* For [i] "i" i.e. info */
-		input[data-task="i"]:checked, li[data-task="i"]>input:checked, li[data-task="i"]>p>input:checked {
+		body.enable-alternative-checkboxes input[data-task="i"]:checked,
+		body.enable-alternative-checkboxes li[data-task="i"]>input:checked,
+		body.enable-alternative-checkboxes li[data-task="i"]>p>input:checked {
 		    --checkbox-color-hover: var(--color-cyan);
 		    color: var(--color-cyan);
 		    -webkit-mask-image: url('data:image/svg+xml;utf8,<?xml version="1.0" encoding="UTF-8"?><svg id="svg0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><defs><style>.cls-1{fill:none;}</style></defs><rect class="cls-1" width="16" height="16"/><g><rect class="cls-1" width="16" height="16"/><path d="M10.67,13v-1.67c0-.1-.03-.18-.09-.24s-.14-.09-.24-.09h-1V5.67c0-.1-.03-.18-.09-.24s-.14-.09-.24-.09h-3.33c-.1,0-.18,.03-.24,.09s-.09,.14-.09,.24v1.67c0,.1,.03,.18,.09,.24s.14,.09,.24,.09h1v3.33h-1c-.1,0-.18,.03-.24,.09s-.09,.14-.09,.24v1.67c0,.1,.03,.18,.09,.24s.14,.09,.24,.09h4.67c.1,0,.18-.03,.24-.09s.09-.14,.09-.24Zm-1.33-9.33v-1.67c0-.1-.03-.18-.09-.24s-.14-.09-.24-.09h-2c-.1,0-.18,.03-.24,.09s-.09,.14-.09,.24v1.67c0,.1,.03,.18,.09,.24s.14,.09,.24,.09h2c.1,0,.18-.03,.24-.09s.09-.14,.09-.24Zm6.67,4.33c0,1.45-.36,2.79-1.07,4.02-.72,1.23-1.69,2.2-2.91,2.91-1.23,.72-2.56,1.07-4.02,1.07s-2.79-.36-4.02-1.07c-1.23-.72-2.2-1.69-2.91-2.91-.72-1.23-1.07-2.56-1.07-4.02S.36,5.21,1.07,3.98c.72-1.23,1.69-2.2,2.91-2.91,1.23-.72,2.56-1.07,4.02-1.07s2.79,.36,4.02,1.07c1.23,.72,2.2,1.69,2.91,2.91,.72,1.23,1.07,2.56,1.07,4.02Z"/></g></svg>');
 		}
 
 		/* For [!] "!" i.e. warning */
-		input[data-task="!"]:checked, li[data-task="!"]>input:checked, li[data-task="!"]>p>input:checked {
+		body.enable-alternative-checkboxes input[data-task="!"]:checked,
+		body.enable-alternative-checkboxes li[data-task="!"]>input:checked,
+		body.enable-alternative-checkboxes li[data-task="!"]>p>input:checked {
 			--checkbox-color-hover: var(--color-red);
 			color: var(--color-orange);
 			-webkit-mask-image: url('data:image/svg+xml;utf8,<?xml version="1.0" encoding="UTF-8"?><svg id="svg0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><defs><style>.cls-1{fill:none;}.cls-2{fill-rule:evenodd;}</style></defs><rect class="cls-1" width="16" height="16"/><path class="cls-2" d="M8,16c4.42,0,8-3.58,8-8S12.42,0,8,0,0,3.58,0,8s3.58,8,8,8ZM6.07,3.55c-.08,.29-.09,.6-.03,.9l.86,4.56c.05,.28,.2,.52,.42,.7,.22,.18,.49,.28,.77,.28s.55-.1,.77-.28c.22-.18,.36-.43,.42-.7l.86-4.56c.06-.3,.04-.61-.03-.9-.08-.29-.22-.57-.41-.8-.19-.23-.44-.42-.71-.55-.28-.13-.58-.2-.88-.2s-.61,.07-.88,.2c-.28,.13-.52,.32-.71,.55-.19,.23-.34,.51-.41,.8Zm3.07,10.01c.28-.28,.44-.66,.44-1.06s-.16-.78-.44-1.06c-.28-.28-.66-.44-1.06-.44s-.78,.16-1.06,.44c-.28,.28-.44,.66-.44,1.06s.16,.78,.44,1.06c.28,.28,.66,.44,1.06,.44s.78-.16,1.06-.44Z"/></svg>');
 		}
 
 		/* For ["] or "“" i.e. citation, my version */
-		input[type=checkbox][data-task="\""]:is(*,:hover,:active),
-		input[type=checkbox][data-task="“"]:is(*,:hover,:active),
-		li[data-task="\""] > input:checked,
-		li[data-task="\""] > p > input:checked,
-		li[data-task="“"] > input:checked,
-		li[data-task="“"] > p > input:checked
-			{ background-color: transparent; }
-		input[type=checkbox][data-task="\""]:checked::after,
-		input[type=checkbox][data-task="“"]:checked::after,
-		li[data-task="\""] > input:checked::after,
-		li[data-task="“"] > input:checked::after,
-		li[data-task="\""] > p > input:checked::after,
-		li[data-task="“"] > p > input:checked::after {
+		body.enable-alternative-checkboxes input[type=checkbox][data-task="\""]:is(*,:hover,:active),
+		body.enable-alternative-checkboxes input[type=checkbox][data-task="“"]:is(*,:hover,:active),
+		body.enable-alternative-checkboxes li[data-task="\""] > input:checked,
+		body.enable-alternative-checkboxes li[data-task="\""] > p > input:checked,
+		body.enable-alternative-checkboxes li[data-task="“"] > input:checked,
+		body.enable-alternative-checkboxes li[data-task="“"] > p > input:checked {
+			background-color: transparent;
+		}
+		body.enable-alternative-checkboxes input[type=checkbox][data-task="\""]:checked::after,
+		body.enable-alternative-checkboxes input[type=checkbox][data-task="“"]:checked::after,
+		body.enable-alternative-checkboxes li[data-task="\""] > input:checked::after,
+		body.enable-alternative-checkboxes li[data-task="“"] > input:checked::after,
+		body.enable-alternative-checkboxes li[data-task="\""] > p > input:checked::after,
+		body.enable-alternative-checkboxes li[data-task="“"] > p > input:checked::after {
 			content: "❝";
 			font-size: 1.6em;
 			text-align: center;
@@ -1178,8 +1207,8 @@
 			background-color: transparent;
 			-webkit-mask-image: revert;
 		}
-		li[data-task="“"] > input:checked::after,
-		li[data-task="“"] > p > input:checked::after
+		body.enable-alternative-checkboxes li[data-task="“"] > input:checked::after,
+		body.enable-alternative-checkboxes li[data-task="“"] > p > input:checked::after
 			{ top: -5px; }
 		/* cite *//*
 		input[data-task="“"]:checked, li[data-task="“"]>input:checked, li[data-task="“"]>p>input:checked {
@@ -1189,13 +1218,13 @@
 		}
 
 		/* For [r] or "r" i.e. reference */
-		input[type=checkbox][data-task="r"]:is(*,:hover,:active),
-		li[data-task="r"] > input:checked,
-		li[data-task="r"] > p > input:checked
+		body.enable-alternative-checkboxes input[type=checkbox][data-task="r"]:is(*,:hover,:active),
+		body.enable-alternative-checkboxes li[data-task="r"] > input:checked,
+		body.enable-alternative-checkboxes li[data-task="r"] > p > input:checked
 			{ background-color: transparent; }
-		input[type=checkbox][data-task="r"]:checked::after,
-		li[data-task="r"] > input:checked::after,
-		li[data-task="r"] > p > input:checked::after {
+		body.enable-alternative-checkboxes input[type=checkbox][data-task="r"]:checked::after,
+		body.enable-alternative-checkboxes li[data-task="r"] > input:checked::after,
+		body.enable-alternative-checkboxes li[data-task="r"] > p > input:checked::after {
 			content: "🕮";
 			font-size: 0.9em;
 			font-weight: bold;
@@ -1207,12 +1236,13 @@
 			-webkit-mask-image: revert;
 		}
 		/* additional adjustment for reading view only */
-		li[data-task="r"] > input:checked::after,
-		li[data-task="r"] > p > input:checked::after
+		body.enable-alternative-checkboxes li[data-task="r"] > input:checked::after,
+		body.enable-alternative-checkboxes li[data-task="r"] > p > input:checked::after
 			{ top: -2px; left: 0px; }
 
 		/* For [*] "*" i.e. Star or Favourites */
-		input[data-task="*"]:checked, li[data-task="*"]>input:checked, li[data-task="*"]>p>input:checked {
+		body.enable-alternative-checkboxes input[data-task="*"]:checked,
+		body.enable-alternative-checkboxes li[data-task="*"]>input:checked, li[data-task="*"]>p>input:checked {
 			--checkbox-color-hover: var(--color-yellow);
 			color: var(--color-yellow);
 			-webkit-mask-image: url('data:image/svg+xml;utf8,<?xml version="1.0" encoding="UTF-8"?><svg id="svg0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><defs><style>.cls-1{fill:none;}</style></defs><rect class="cls-1" width="16" height="16"/><path d="M8.91,.58c-.08-.17-.21-.32-.37-.42C8.38,.05,8.19,0,8,0s-.38,.05-.54,.16c-.16,.1-.29,.25-.37,.42l-1.93,4.12L.85,5.36c-.18,.03-.35,.1-.49,.22-.14,.12-.25,.27-.3,.45-.06,.17-.07,.36-.03,.54,.04,.18,.13,.34,.26,.48l3.15,3.23-.75,4.57c-.03,.19,0,.38,.06,.55,.07,.17,.19,.32,.35,.43,.15,.11,.33,.17,.52,.18,.19,0,.37-.03,.54-.12l3.84-2.13,3.84,2.13c.16,.09,.35,.13,.54,.12,.19-.01,.37-.07,.52-.18,.15-.11,.27-.26,.35-.43,.07-.17,.09-.36,.06-.55l-.75-4.57,3.15-3.23c.13-.13,.22-.3,.26-.48,.04-.18,.03-.37-.03-.54-.06-.17-.16-.33-.31-.45-.14-.12-.31-.2-.49-.22l-4.31-.66L8.91,.58Z"/></svg>');
@@ -1223,38 +1253,38 @@
 		/* -- background option. for info/highlight alternate checkbox */
 
 			/* setting the color for each label */
-			.HyperMD-list-line:has(> .task-list-label > [data-task="I"])::after,
-			li[data-task="I"]::after
+			body.enable-alternative-checkboxes .HyperMD-list-line:has(> .task-list-label > [data-task="I"])::after,
+			body.enable-alternative-checkboxes li[data-task="I"]::after
 				{ background: rgba(var(--color-yellow-rgb), 0.18); }
-			.HyperMD-list-line:has(> .task-list-label > [data-task="i"])::after,
-			li[data-task="i"]::after
+			body.enable-alternative-checkboxes .HyperMD-list-line:has(> .task-list-label > [data-task="i"])::after,
+			body.enable-alternative-checkboxes li[data-task="i"]::after
 				{ background: rgba(var(--color-purple-rgb), 0.18); }
-			.HyperMD-list-line:has(> .task-list-label > [data-task="\""])::after,
-			.HyperMD-list-line:has(> .task-list-label > [data-task="“"])::after,
-			li[data-task="\""]::after,
-			li[data-task="“"]::after
+			body.enable-alternative-checkboxes .HyperMD-list-line:has(> .task-list-label > [data-task="\""])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line:has(> .task-list-label > [data-task="“"])::after,
+			body.enable-alternative-checkboxes li[data-task="\""]::after,
+			body.enable-alternative-checkboxes li[data-task="“"]::after
 				{ background: rgba(var(--callout-quote), 0.18); }
-			.HyperMD-list-line:has(> .task-list-label > [data-task="!"])::after,
-			li[data-task="!"]::after
+			body.enable-alternative-checkboxes .HyperMD-list-line:has(> .task-list-label > [data-task="!"])::after,
+			body.enable-alternative-checkboxes li[data-task="!"]::after
 				{ background: rgba(var(--color-red-rgb), 0.18); }
-			.HyperMD-list-line:has(> .task-list-label > [data-task="r"])::after,
-			li[data-task="r"]::after
+			body.enable-alternative-checkboxes .HyperMD-list-line:has(> .task-list-label > [data-task="r"])::after,
+			body.enable-alternative-checkboxes li[data-task="r"]::after
 				{ background: rgba(var(--callout-quote), 0.18); }
-			.HyperMD-list-line:has(> .task-list-label > [data-task="*"])::after,
-			li[data-task="*"]::after
+			body.enable-alternative-checkboxes .HyperMD-list-line:has(> .task-list-label > [data-task="*"])::after,
+			body.enable-alternative-checkboxes li[data-task="*"]::after
 				{ background: rgba(var(--color-orange-rgb), 0.18); }
 
 			/* adjust the background position, common to all types */
-			body {
+			body.enable-alternative-checkboxes {
 				--alt-checkbox-bg-content: '';
 			}
-			.HyperMD-list-line:has(> .task-list-label > [data-task="I"])::after,
-			.HyperMD-list-line:has(> .task-list-label > [data-task="i"])::after,
-			.HyperMD-list-line:has(> .task-list-label > [data-task="\""])::after,
-			.HyperMD-list-line:has(> .task-list-label > [data-task="“"])::after,
-			.HyperMD-list-line:has(> .task-list-label > [data-task="!"])::after,
-			.HyperMD-list-line:has(> .task-list-label > [data-task="r"])::after,
-			.HyperMD-list-line:has(> .task-list-label > [data-task="*"])::after {
+			body.enable-alternative-checkboxes .HyperMD-list-line:has(> .task-list-label > [data-task="I"])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line:has(> .task-list-label > [data-task="i"])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line:has(> .task-list-label > [data-task="\""])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line:has(> .task-list-label > [data-task="“"])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line:has(> .task-list-label > [data-task="!"])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line:has(> .task-list-label > [data-task="r"])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line:has(> .task-list-label > [data-task="*"])::after {
 		        content: var(--alt-checkbox-bg-content); position: absolute;
 		        inset: 1px 0em 0 1.6em;
 		        height: calc(100% -  1px); width: calc(100% - 1.6em);
@@ -1263,55 +1293,55 @@
 		    }
 
 			/* move the background in line with list level */
-			.HyperMD-list-line-2:has(> .task-list-label > [data-task="I"])::after,
-			.HyperMD-list-line-2:has(> .task-list-label > [data-task="i"])::after,
-			.HyperMD-list-line-2:has(> .task-list-label > [data-task="\""])::after,
-			.HyperMD-list-line-2:has(> .task-list-label > [data-task="“"])::after,
-			.HyperMD-list-line-2:has(> .task-list-label > [data-task="!"])::after,
-			.HyperMD-list-line-2:has(> .task-list-label > [data-task="r"])::after,
-			.HyperMD-list-line-2:has(> .task-list-label > [data-task="*"])::after {
+			body.enable-alternative-checkboxes .HyperMD-list-line-2:has(> .task-list-label > [data-task="I"])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line-2:has(> .task-list-label > [data-task="i"])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line-2:has(> .task-list-label > [data-task="\""])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line-2:has(> .task-list-label > [data-task="“"])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line-2:has(> .task-list-label > [data-task="!"])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line-2:has(> .task-list-label > [data-task="r"])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line-2:has(> .task-list-label > [data-task="*"])::after {
 				left: 3.55em;
 				width: calc(100% - 3.55em);
 			}
-			.HyperMD-list-line-3:has(> .task-list-label > [data-task="I"])::after,
-			.HyperMD-list-line-3:has(> .task-list-label > [data-task="i"])::after,
-			.HyperMD-list-line-3:has(> .task-list-label > [data-task="\""])::after,
-			.HyperMD-list-line-3:has(> .task-list-label > [data-task="“"])::after,
-			.HyperMD-list-line-3:has(> .task-list-label > [data-task="!"])::after,
-			.HyperMD-list-line-3:has(> .task-list-label > [data-task="r"])::after,
-			.HyperMD-list-line-3:has(> .task-list-label > [data-task="*"])::after {
+			body.enable-alternative-checkboxes .HyperMD-list-line-3:has(> .task-list-label > [data-task="I"])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line-3:has(> .task-list-label > [data-task="i"])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line-3:has(> .task-list-label > [data-task="\""])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line-3:has(> .task-list-label > [data-task="“"])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line-3:has(> .task-list-label > [data-task="!"])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line-3:has(> .task-list-label > [data-task="r"])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line-3:has(> .task-list-label > [data-task="*"])::after {
 				left: 5.15em;
 				width: calc(100% - 5.15em);
 			}
-			.HyperMD-list-line-4:has(> .task-list-label > [data-task="I"])::after,
-			.HyperMD-list-line-4:has(> .task-list-label > [data-task="i"])::after,
-			.HyperMD-list-line-4:has(> .task-list-label > [data-task="\""])::after,
-			.HyperMD-list-line-4:has(> .task-list-label > [data-task="“"])::after,
-			.HyperMD-list-line-4:has(> .task-list-label > [data-task="!"])::after,
-			.HyperMD-list-line-4:has(> .task-list-label > [data-task="r"])::after,
-			.HyperMD-list-line-4:has(> .task-list-label > [data-task="*"])::after {
+			body.enable-alternative-checkboxes .HyperMD-list-line-4:has(> .task-list-label > [data-task="I"])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line-4:has(> .task-list-label > [data-task="i"])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line-4:has(> .task-list-label > [data-task="\""])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line-4:has(> .task-list-label > [data-task="“"])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line-4:has(> .task-list-label > [data-task="!"])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line-4:has(> .task-list-label > [data-task="r"])::after,
+			body.enable-alternative-checkboxes .HyperMD-list-line-4:has(> .task-list-label > [data-task="*"])::after {
 				left: 6.75em;
 				width: calc(100% - 6.75em);
 			}
 
 			/* general setup for background in reading view */
-		    li[data-task="I"],
-			li[data-task="i"],
-			li[data-task="\""],
-			li[data-task="“"],
-			li[data-task="!"],
-			li[data-task="r"],
-			li[data-task="*"] {
+		    body.enable-alternative-checkboxes li[data-task="I"],
+			body.enable-alternative-checkboxes li[data-task="i"],
+			body.enable-alternative-checkboxes li[data-task="\""],
+			body.enable-alternative-checkboxes li[data-task="“"],
+			body.enable-alternative-checkboxes li[data-task="!"],
+			body.enable-alternative-checkboxes li[data-task="r"],
+			body.enable-alternative-checkboxes li[data-task="*"] {
 		        position: relative;
 		        z-index: 30;
 		    }
-		    li[data-task="I"]::after,
-			li[data-task="i"]::after,
-			li[data-task="\""]::after,
-			li[data-task="“"]::after,
-			li[data-task="!"]::after,
-			li[data-task="r"]::after,
-			li[data-task="*"]::after {
+		    body.enable-alternative-checkboxes li[data-task="I"]::after,
+			body.enable-alternative-checkboxes li[data-task="i"]::after,
+			body.enable-alternative-checkboxes li[data-task="\""]::after,
+			body.enable-alternative-checkboxes li[data-task="“"]::after,
+			body.enable-alternative-checkboxes li[data-task="!"]::after,
+			body.enable-alternative-checkboxes li[data-task="r"]::after,
+			body.enable-alternative-checkboxes li[data-task="*"]::after {
 		        content: ''; position: absolute;
 		        top: 1px; left: -0.25em;
 		        height: calc(100% - 1px); width: calc(100% + 0.25em);
@@ -2572,6 +2602,12 @@ settings:
 		type: heading
 		level: 2
 		collapsed: true
+	-
+	    id: enable-alternative-checkboxes
+		title: Enable Alternative Checkboxes
+		description: Disable this if you are using your own implementation via a CSS Snippet.
+		default: true
+		type: class-toggle
 	-
 		id: alt-checkbox-bg-content
         title: Background Option


### PR DESCRIPTION
This implements the feature mentioned in this issue: https://github.com/efemkay/obsidian-listive-theme/issues/8

- I've implemented the toggle feature in Style Settings.
- By default, your Alternative Checkbox styling is applied and the toggle can disable it.

Once toggled to disable, the Alternative Checkboxes are reset to default styling:
![image](https://github.com/user-attachments/assets/28600451-17e9-4652-84f6-a239bd413433)

I wasn't sure how you handle version bumping so I didn't change anything for that.